### PR TITLE
Add Cloud Agent development environment (.NET 6)

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "Processor-Emulator",
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Cloud Agent bootstrap for the Processor-Emulator repository.
+#
+# The primary product (ProcessorEmulator.csproj) is a Windows-only WPF/WinForms
+# app (net6.0-windows) and can neither build with markup compilation nor run on
+# Linux. Cloud Agents run Linux, so this script provisions the .NET 6 SDK the
+# repo pins and warms the cross-platform console demo (BoltDemo_Standalone),
+# which is the component that actually builds AND runs on Linux.
+#
+# The script is idempotent: re-running it skips an already-installed SDK and
+# only refreshes the demo build.
+set -euo pipefail
+
+DOTNET_DIR="/usr/local/dotnet"
+DOTNET_CHANNEL="6.0"
+
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_NOLOGO=1
+
+if [ ! -x "${DOTNET_DIR}/dotnet" ]; then
+  echo "Installing .NET SDK ${DOTNET_CHANNEL} into ${DOTNET_DIR}..."
+  tmp="$(mktemp -d)"
+  curl -fsSL https://dot.net/v1/dotnet-install.sh -o "${tmp}/dotnet-install.sh"
+  chmod +x "${tmp}/dotnet-install.sh"
+  sudo mkdir -p "${DOTNET_DIR}"
+  sudo "${tmp}/dotnet-install.sh" --channel "${DOTNET_CHANNEL}" --install-dir "${DOTNET_DIR}"
+  rm -rf "${tmp}"
+else
+  echo ".NET SDK already present: $(${DOTNET_DIR}/dotnet --version)"
+fi
+
+# Expose dotnet on PATH for interactive agent shells (idempotent symlink).
+sudo ln -sf "${DOTNET_DIR}/dotnet" /usr/local/bin/dotnet
+
+export DOTNET_ROOT="${DOTNET_DIR}"
+export PATH="${DOTNET_DIR}:${PATH}"
+
+echo "Using dotnet $(dotnet --version)"
+
+# Warm up the cross-platform console demo (restore + build). This is the target
+# that runs end-to-end on Linux.
+dotnet build BoltDemo_Standalone/BoltDemo.csproj -c Release
+
+echo "Environment ready."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cloud Agent development environment for this repository so future agents boot with a working .NET toolchain.

The primary product (`ProcessorEmulator.csproj`) is a **Windows-only** WPF/WinForms app (`net6.0-windows`) — WPF has no Linux runtime, and its markup compilation/execution require Windows (this matches the repo's CI, which runs exclusively on `windows-latest`). It therefore cannot build or run on a Linux Cloud Agent VM.

What *does* work cross-platform is the emulation-core console demo in `BoltDemo_Standalone/` (`net6.0`). This environment provisions the SDK the repo pins and warms that demo, which builds **and** runs end-to-end on Linux.

## Changes

- `.cursor/environment.json` — declares the environment and its `install` command.
- `.cursor/install.sh` — idempotent bootstrap that:
  - installs the .NET 6 SDK (6.0.428) system-wide to `/usr/local/dotnet` via the official `dotnet-install.sh`, skipping if already present;
  - symlinks `dotnet` onto `PATH` at `/usr/local/bin/dotnet`;
  - restores and builds `BoltDemo_Standalone/BoltDemo.csproj` (`-c Release`).

## Validation

- Fresh install run: SDK installed, demo built (0 warnings, 0 errors).
- Re-run: idempotent (`All projects are up-to-date for restore`, SDK install skipped).
- `dotnet` resolves via the PATH symlink in a clean shell with no extra env vars.
- `BoltDemo_Standalone` runs end-to-end: BOLT SoC init, memory test, device-tree dump, firmware load, and a 10-instruction ARM trace ending at the halt instruction ("ARM emulation simulation completed successfully!").

## Notes

- No application code was modified; this is environment configuration only.
- The `main` branch's Windows build is currently red for unrelated reasons (a deprecated `actions/upload-artifact@v3` gate and a pre-existing malformed `MainWindow.xaml`); neither is addressed here.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c07b513c-f769-4091-a0b0-5a3db94be02b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c07b513c-f769-4091-a0b0-5a3db94be02b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

